### PR TITLE
add sensitive flag to aws variables

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,9 +1,11 @@
 variable "access_key" {
   description = "AWS access key"
+  sensitive = true
 }
 
 variable "secret_key" {
   description = "AWS secret access key"
+  sensitive = true
 }
 
 variable "region" {


### PR DESCRIPTION
Adding the `sensitive = true` flag to the aws credentials variables ensures that terraform does not accidentally expose this data in CLI output, log output, or source control.